### PR TITLE
remove mut prefix

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -64,12 +64,12 @@ impl Dispatcher {
             F: FnMut(Rc<T>) + 'static,
             T: 'static
     {
-        let mut subs = match self.map.get_mut(&TypeId::of::<T>()) {
+        match self.map.get_mut(&TypeId::of::<T>()) {
             None => panic!("Can't subscribe to a message which is not registered!"),
             Some(subs) => subs
         };
 
-        let mut wrapped = move |msg: *const ()| {
+        let wrapped = move |msg: *const ()| {
             let typed = unsafe { Rc::from_raw(msg as *const T) };
             (f)(typed)
         };
@@ -84,7 +84,7 @@ impl Dispatcher {
     /// It is safe to be called because of the mapping that ensures the correct messages are
     /// distributed to subscribers expecting them.
     pub fn dispatch<T: 'static>(&mut self, msg: Rc<T>) {
-        let mut subscribers = self.map.get_mut(&TypeId::of::<T>())
+        let subscribers = self.map.get_mut(&TypeId::of::<T>())
             .expect("Can not dispatch a message which has not been registered");
 
         for subscriber in subscribers.iter_mut() {
@@ -106,7 +106,7 @@ mod tests {
         greeting: String
     }
 
-    struct Farawell {
+    struct Farewell {
         farawell: String
     }
 
@@ -129,7 +129,7 @@ mod tests {
         let called = Rc::new(RefCell::new(false));
         {
             let called = called.clone();
-            let mut pop = move |msg| {
+            let pop = move |msg| {
                 *called.borrow_mut() = true;
                 pop(msg);
             };

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::dispatcher::Dispatcher;
 
     struct Greeting { greeting: String }
-    struct Farawell { farawell: String }
+    struct Farewell { farewell: String }
     struct Context { answer: i32, called: bool }
 
     fn context_pop(ctx: &mut Context, msg: Rc<Greeting>) {
@@ -147,27 +147,27 @@ mod tests {
         let mut dispatcher_b = Dispatcher::new();
 
         dispatcher_a.register::<Greeting>();
-        dispatcher_b.register::<Farawell>();
+        dispatcher_b.register::<Farewell>();
 
         let mut queue = Queue::<()>::new();
         queue.register::<Greeting>(&mut dispatcher_a);
-        queue.register::<Farawell>(&mut dispatcher_b);
+        queue.register::<Farewell>(&mut dispatcher_b);
 
         let handle_greeting = |_: &mut (), msg: Rc<Greeting>| {
             assert_eq!(msg.greeting, "Hello, World!");
         };
-        let handle_farawell = |_: &mut (), msg: Rc<Farawell>| {
-            assert_eq!(msg.farawell, "Goodbye!");
+        let handle_farewell = |_: &mut (), msg: Rc<Farewell>| {
+            assert_eq!(msg.farewell, "Goodbye!");
         };
 
         queue.subscribe(&mut dispatcher_a, handle_greeting);
-        queue.subscribe(&mut dispatcher_b, handle_farawell);
+        queue.subscribe(&mut dispatcher_b, handle_farewell);
 
         dispatcher_a.dispatch(Rc::new(Greeting {
             greeting: "Hello, World!".to_string()
         }));
-        dispatcher_b.dispatch(Rc::new(Farawell {
-            farawell: "Goodbye!".to_string()
+        dispatcher_b.dispatch(Rc::new(Farewell {
+            farewell: "Goodbye!".to_string()
         }));
 
         queue.poll(&mut ());


### PR DESCRIPTION
`mut` is not needed where it has been removed
`let mut subs` is not reused anywhere 